### PR TITLE
Update sim_dtm.cc to fix compile error for bfd_section_size() parameter

### DIFF
--- a/src/main/resources/csrc/sim_dtm.cc
+++ b/src/main/resources/csrc/sim_dtm.cc
@@ -406,7 +406,7 @@ static void load_bitfile (bfd *b, asection *section, PTR data)
 
 static void load_hex (bfd *b, asection *section, Memory *p_memory)
 {
-  int size = bfd_section_size (b, section);
+  int size = bfd_section_size (section);
   std::unique_ptr<Byte_t[]> buf (new Byte_t[size]);
   // fprintf (stderr, "<Allocate %d>\n", size);
 


### PR DESCRIPTION
Hello 

I faced a compile error, so I need this fix.
Here is some information for your reference.

- /usr/include/bfd.h
  - bfd_section_size (const asection *sec) 

- os & package version
  - DISTRIB_DESCRIPTION="Ubuntu 20.04.1 LTS"
  - binutils-dev/focal,now 2.34-6ubuntu1 amd64 [installed]
